### PR TITLE
Atualização pagseguro.php

### DIFF
--- a/admin/controller/extension/payment/pagseguro.php
+++ b/admin/controller/extension/payment/pagseguro.php
@@ -322,7 +322,7 @@ class ControllerExtensionPaymentPagSeguro extends Controller
 		if (empty($this->request->post['payment_pagseguro_token']))
 			$this->error['token'] = $this->language->get('error_token_required');
 
-		if (strlen(trim($this->request->post['payment_pagseguro_token'])) != 32 && !(empty($this->request->post['payment_pagseguro_token'])))
+		if (strlen(trim($this->request->post['payment_pagseguro_token'])) != 100 && !(empty($this->request->post['payment_pagseguro_token'])))
 			$this->error['token'] = $this->language->get('error_token_invalid');
 	}
 


### PR DESCRIPTION
Desde o dia 28/03/2019, os tokens gerados via iBanking > Venda Online > Integrações > Gerar Token contém 100 caracteres, e não mais 32 como anteriormente.

Isso porque o PagSeguro identificou que essa alteração gera ainda mais segurança no momento de transacionar.